### PR TITLE
Delete /run/var/* without sudo rights

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -14,6 +14,9 @@ fi
 echo -e "\nSTEP: cleaning up previous database data directory"
 sudo rm -rfv "run/var/*"
 
+echo -e "\nSTEP: clean up previous database data directory without sudo rights"
+rm -rfv "run/var/*"
+
 echo -e "\nSTEP: cleaning up previous docker-compose containers"
 docker-compose down
 


### PR DESCRIPTION
- The Git Bash shell on Windows doesn't have a sudo command.
  Therefore the sudo rm command will fail.
  This commit fixes this by deleting the folder without sudo rights.